### PR TITLE
test: fix failing android native tests FGR3-7200

### DIFF
--- a/.github/workflows/run-native-tests.yml
+++ b/.github/workflows/run-native-tests.yml
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
   android:
-    if: false # Temporarily skip Android tests
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout

--- a/android/src/test/java/com/reactnative/localserver/TCPServerModuleTest.java
+++ b/android/src/test/java/com/reactnative/localserver/TCPServerModuleTest.java
@@ -56,11 +56,11 @@ public class TCPServerModuleTest {
     public void shouldCreateServer() throws Exception {
         TCPServerModule module = new TCPServerModule(context, eventEmitter, serverFactory, nsdManagerFactory);
         when(nsdManagerFactory.of()).thenReturn(nsdManager);
-        when(serverFactory.of("server-1", 12000, null, null, eventEmitter)).thenReturn(server);
+        when(serverFactory.of("server-1", 12000, null, true, eventEmitter)).thenReturn(server);
 
         module.createServer("server-1", 12000, promise);
 
-        verify(serverFactory).of("server-1", 12000, null, null, eventEmitter);
+        verify(serverFactory).of("server-1", 12000, null, true, eventEmitter);
         verify(server).start(nsdManager);
         verify(promise).resolve(true);
         assertThat(module.getServers()).containsEntry("server-1", server);
@@ -70,12 +70,12 @@ public class TCPServerModuleTest {
     public void shouldNotCreateServer_ServerExists() throws Exception {
         TCPServerModule module = new TCPServerModule(context, eventEmitter, serverFactory, nsdManagerFactory);
         when(nsdManagerFactory.of()).thenReturn(nsdManager);
-        when(serverFactory.of("server-1", 12000, null, null, eventEmitter)).thenReturn(server);
+        when(serverFactory.of("server-1", 12000, null, true, eventEmitter)).thenReturn(server);
 
         module.createServer("server-1", 12000, promise);
         module.createServer("server-1", 12000, promise);
 
-        verify(serverFactory, times(1)).of("server-1", 12000, null, null, eventEmitter);
+        verify(serverFactory, times(1)).of("server-1", 12000, null, true, eventEmitter);
         verify(server, times(1)).start(nsdManager);
         verify(promise, times(1)).resolve(true);
         verify(promise, times(1)).reject("tcp.server.already-exists", "Server with this id already exists");
@@ -88,12 +88,12 @@ public class TCPServerModuleTest {
         Exception exception = new UnknownHostException("Could not connect to localhost:12000");
         TCPServerModule module = new TCPServerModule(context, eventEmitter, serverFactory, nsdManagerFactory);
         when(nsdManagerFactory.of()).thenReturn(nsdManager);
-        when(serverFactory.of("server-1", 12000, null, false, eventEmitter)).thenReturn(server);
+        when(serverFactory.of("server-1", 12000, null, true, eventEmitter)).thenReturn(server);
         doThrow(exception).when(server).start(nsdManager);
 
         module.createServer("server-1", 12000, promise);
 
-        verify(serverFactory, times(1)).of("server-1", 12000, null, false, eventEmitter);
+        verify(serverFactory, times(1)).of("server-1", 12000, null, true, eventEmitter);
         verify(server, times(1)).start(nsdManager);
         verify(promise, times(1)).reject("tcp.server.error", exception.getMessage());
         assertThat(module.getServers()).doesNotContainEntry("server-1", server);
@@ -102,7 +102,7 @@ public class TCPServerModuleTest {
     @Test
     public void shouldStopServer() throws Exception {
         TCPServerModule module = new TCPServerModule(context, eventEmitter, serverFactory, nsdManagerFactory);
-        when(serverFactory.of("server-1", 12000, null, false, eventEmitter)).thenReturn(server);
+        when(serverFactory.of("server-1", 12000, null, true, eventEmitter)).thenReturn(server);
 
         module.createServer("server-1", 12000, promise);
         module.stopServer("server-1", null, promise2);
@@ -123,7 +123,7 @@ public class TCPServerModuleTest {
     public void shouldNotStopServer_ServerStopThrowsException() throws Exception {
         Exception exception = new Exception("Failed to stop server");
         TCPServerModule module = new TCPServerModule(context, eventEmitter, serverFactory, nsdManagerFactory);
-        when(serverFactory.of("server-1", 12000, null, false, eventEmitter)).thenReturn(server);
+        when(serverFactory.of("server-1", 12000, null, true, eventEmitter)).thenReturn(server);
         doThrow(exception).when(server).stop(null);
 
         module.createServer("server-1", 12000, promise);
@@ -138,7 +138,7 @@ public class TCPServerModuleTest {
     public void shouldSendData() throws Exception {
         String message = "This is the message";
         TCPServerModule module = new TCPServerModule(context, eventEmitter, serverFactory, nsdManagerFactory);
-        when(serverFactory.of("server-1", 12000, null, false, eventEmitter)).thenReturn(server);
+        when(serverFactory.of("server-1", 12000, null, true, eventEmitter)).thenReturn(server);
         module.createServer("server-1", 12000, promise);
         module.send("server-1", "connection-1", message, promise2);
 
@@ -151,7 +151,7 @@ public class TCPServerModuleTest {
         String message = "This is the message";
         Exception exception = new Exception("Failed to send message");
         TCPServerModule module = new TCPServerModule(context, eventEmitter, serverFactory, nsdManagerFactory);
-        when(serverFactory.of("server-1", 12000, null, false, eventEmitter)).thenReturn(server);
+        when(serverFactory.of("server-1", 12000, null, true, eventEmitter)).thenReturn(server);
         doThrow(exception).when(server).send("connection-1", message);
 
         module.createServer("server-1", 12000, promise);
@@ -174,7 +174,7 @@ public class TCPServerModuleTest {
     @Test
     public void shouldInvalidate() throws Exception {
         TCPServerModule module = new TCPServerModule(context, eventEmitter, serverFactory, nsdManagerFactory);
-        when(serverFactory.of("server-1", 12000, null, false, eventEmitter)).thenReturn(server);
+        when(serverFactory.of("server-1", 12000, null, true, eventEmitter)).thenReturn(server);
 
         module.createServer("server-1", 12000, promise);
 
@@ -187,7 +187,7 @@ public class TCPServerModuleTest {
     public void shouldInvalidate_EvenWhenStopFails() throws Exception {
         Exception exception = new Exception("Failed to stop server");
         TCPServerModule module = new TCPServerModule(context, eventEmitter, serverFactory, nsdManagerFactory);
-        when(serverFactory.of("server-1", 12000, null, false, eventEmitter)).thenReturn(server);
+        when(serverFactory.of("server-1", 12000, null, true, eventEmitter)).thenReturn(server);
         doThrow(exception).when(server).stop(StopReasonEnum.Invalidation);
 
         module.createServer("server-1", 12000, promise);

--- a/android/src/test/java/com/reactnative/localserver/tcp/E2E.java
+++ b/android/src/test/java/com/reactnative/localserver/tcp/E2E.java
@@ -230,7 +230,7 @@ public class E2E {
 
         Promise promise = mockPromise();
         clientModule.createClient("client", "localhost", port + 1, promise);
-        verify(promise).reject("tcp.client.error", "Connection refused (Connection refused)");
+        verify(promise).reject("tcp.client.error", "Connection refused");
 
         TimeUnit.MILLISECONDS.sleep(100);
 

--- a/android/src/test/java/com/reactnative/localserver/udp/E2E.java
+++ b/android/src/test/java/com/reactnative/localserver/udp/E2E.java
@@ -91,9 +91,9 @@ public class E2E {
 
     @Test
     public void serverShouldNotStartIdAlreadyInUse() throws Exception {
-        prepareServer("server-1", 12000);
+        prepareServer("server-1", 12010);
         Promise promise = mockPromise();
-        serverModule.createServer("server-1", 12001, 0, promise);
+        serverModule.createServer("server-1", 12011, 0, promise);
         verify(promise).reject("udp.server.already-exists", "Server with this id already exists");
     }
 


### PR DESCRIPTION
The changed param for `serverFactory.of()` is something called `useJmDNS`, which should apparently always be true (maybe after migration?)