### PR TITLE
fix: fix combineHandlers types

### DIFF
--- a/example/src/screens/Counter/client/rootHandler.ts
+++ b/example/src/screens/Counter/client/rootHandler.ts
@@ -2,5 +2,4 @@ import { combineHandlers } from "@figuredev/react-native-local-server"
 
 import handlers from "./handlers"
 
-// @ts-expect-error - I don't know what to do with this
 export const rootHandler = combineHandlers(...handlers)

--- a/example/src/screens/Counter/server/rootHandler.ts
+++ b/example/src/screens/Counter/server/rootHandler.ts
@@ -2,5 +2,4 @@ import { combineHandlers } from "@figuredev/react-native-local-server"
 
 import handlers from "./handlers"
 
-// @ts-expect-error - I don't know what to do with this
 export const rootHandler = combineHandlers(...handlers)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@figuredev/react-native-local-server",
-    "version": "0.17.6",
+    "version": "0.17.7",
     "description": "Library for creating a local server on the device running React Native.",
     "main": "lib/commonjs/index",
     "module": "lib/module/index",

--- a/src/messaging/functions/combineHandlers.ts
+++ b/src/messaging/functions/combineHandlers.ts
@@ -2,8 +2,10 @@ import { merge } from "rxjs"
 
 import { MessageHandler } from "../types"
 
-export const combineHandlers = (...handlers: MessageHandler<unknown>[]): MessageHandler<unknown> => {
-    return (...args: Parameters<MessageHandler<unknown>>) =>
+export const combineHandlers = <In, Deps, Result>(
+    ...handlers: MessageHandler<In, Deps, Result>[]
+): MessageHandler<In, Deps, Result> => {
+    return (...args: Parameters<MessageHandler<In, Deps, Result>>) =>
         merge(
             ...handlers.map((handler) => {
                 return handler(...args)


### PR DESCRIPTION
I won't be fixing this type error as it is too complex: https://github.com/FigurePOS/figure-cfd/pull/308#discussion_r3214747566

I believe it should be caused by using `unknown` as a default in type generics -> I believe in that cases it is fine to use `any`.